### PR TITLE
Parent path and nuget stuff

### DIFF
--- a/ansible/roles/atomic_red_team/tasks/main.yml
+++ b/ansible/roles/atomic_red_team/tasks/main.yml
@@ -5,10 +5,25 @@
 #     path: 'C:\AtomicRedTeam'
 #   register: atr_folder
 
+- name: Enable strong dotnet crypto
+  win_regedit:
+    key: "{{ item }}"
+    value: SchUseStrongCrypto
+    datatype: dword
+    data: 1
+  with_items:
+    - "HKLM:\\SOFTWARE\\Microsoft\\.NetFramework\\v4.0.30319"
+    - "HKLM:\\SOFTWARE\\Wow6432Node\\Microsoft\\.NetFramework\\v4.0.30319"
+
+- name: Check installed providers
+  win_shell: Get-PackageProvider
+  register: providers
+  changed_when: false
+
 - name: Install NuGet Provider
   win_shell: |
-    [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
     Install-PackageProvider -Name NuGet -MinimumVersion 2.8.5.201 -Force
+  when: providers.stdout is not search("NuGet")
 
 - name: Install Atomic Red Team
   win_shell: |

--- a/modules/VagrantController.py
+++ b/modules/VagrantController.py
@@ -94,7 +94,7 @@ class VagrantController():
         # get ip address from machine
         self.check_targets_running_vagrant(target, self.log)
         target_ip = self.get_ip_address_from_machine(target)
-        runner = ansible_runner.run(private_data_dir='../attack_range_local/',
+        runner = ansible_runner.run(private_data_dir='.',
                                cmdline=str('-i ' + target_ip + ', '),
                                roles_path="ansible/roles",
                                playbook='ansible/atomic_red_team.yml',


### PR DESCRIPTION
* Fixes a hard-coded path to close #2
* Fix for occasional NuGet installation errors: enable strong encryption instead of forcing TLS1.2 since that doesn't always seem to work