### PR TITLE
default_nic_type

### DIFF
--- a/vagrant/windows-domain-controller/Vagrantfile
+++ b/vagrant/windows-domain-controller/Vagrantfile
@@ -34,7 +34,6 @@ config.vm.define "attack-range-windows-domain-controller" do |config|
   config.vm.provider "virtualbox" do |vb, override|
     vb.gui = true
     vb.name = "#{VM_NAME_WIN_DC}"
-    vb.default_nic_type = "82545EM"
     vb.customize ["modifyvm", :id, "--memory", 2048]
     vb.customize ["modifyvm", :id, "--cpus", 1]
     vb.customize ["modifyvm", :id, "--vram", "32"]


### PR DESCRIPTION
"default_nic_type" causing an error when building windows domain controller. Removed line.