### PR TITLE
disable vagrant synced_folder for wsl compatibility

### DIFF
--- a/vagrant/windows-domain-controller/Vagrantfile
+++ b/vagrant/windows-domain-controller/Vagrantfile
@@ -11,6 +11,7 @@ config.vm.define "attack-range-windows-domain-controller" do |config|
   config.winrm.retry_limit = 20
   config.vm.network "forwarded_port", guest: 5985, host: 6000
   config.vm.network :private_network, ip: "{{ windows_domain_controller_private_ip }}"
+  config.vm.synced_folder '.', '/vagrant', disabled: true
 
   config.vm.provision "ansible" do |ansible|
       ansible.extra_vars = {

--- a/vagrant/windows-server/Vagrantfile
+++ b/vagrant/windows-server/Vagrantfile
@@ -12,6 +12,7 @@ config.vm.define "attack-range-windows-server" do |config|
   config.winrm.retry_limit = 20
   config.vm.network "forwarded_port", guest: 5985, host: 6001
   config.vm.network :private_network, ip: "{{ windows_server_private_ip }}"
+  config.vm.synced_folder '.', '/vagrant', disabled: true
 
   config.vm.provision "ansible" do |ansible|
       ansible.extra_vars = {

--- a/vagrant/windows10/Vagrantfile
+++ b/vagrant/windows10/Vagrantfile
@@ -9,6 +9,7 @@ config.vm.define "attack-range-win10" do |config|
   config.winrm.retry_limit = 20
   config.vm.network "forwarded_port", guest: 5985, host: 5985
   config.vm.network :private_network, ip: "{{ windows_client_private_ip }}"
+  config.vm.synced_folder '.', '/vagrant', disabled: true
 
   config.vm.provision "ansible" do |ansible|
       ansible.extra_vars = {


### PR DESCRIPTION
Although the project doesn't state compatibility for windows it works fine on WSL after applying this simple patch. I couldn't find any dependency on folder synchronization that prevents this adjustment.